### PR TITLE
Removal of unneeded indirection, Error codes, Signed date type for pre 1970 dates

### DIFF
--- a/main.c
+++ b/main.c
@@ -3,28 +3,21 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <err.h>
 
 const int SECONDS_PER_DAY = 86400;
 const char VERSION[] = "1.0.1";
 const size_t DATE_STR_SIZE = 11; // YYYY-MM-DD\0
-const size_t TIME_STR_SIZE = 9; // HH:MM:SS\0
-
-// Get UNIX day from raw time
-uint64_t get_unix_day(time_t t)
-{
-    return t / SECONDS_PER_DAY;
-}
 
 // Convert UNIX day to formatted date
-char* unix_day_to_date(uint64_t ud)
+char* unix_day_to_date(int64_t ud)
 {
     time_t rawtime = ud * SECONDS_PER_DAY;
     struct tm* timeinfo;
     char* buffer = (char*)malloc(DATE_STR_SIZE);
 
     if (!buffer) {
-        fprintf(stderr, "Memory allocation failed.\n");
-        exit(EXIT_FAILURE);
+        err(EXIT_FAILURE, "Memory allocation failed.\n");
     }
 
     timeinfo = gmtime(&rawtime);
@@ -34,17 +27,13 @@ char* unix_day_to_date(uint64_t ud)
 }
 
 // Convert date string to UNIX day
-int date_string_to_unix_day(uint64_t* unix_day, char* date_string)
+int date_string_to_unix_day(int64_t* unix_day, char* date_string)
 {
     struct tm tm = { 0 };
-    char* success;
 
-    success = strptime(date_string, "%Y-%m-%d", &tm) ? "%Y-%m-%d"
-        : strptime(date_string, "%d.%m.%Y", &tm)     ? "%d.%m.%Y"
-        : strptime(date_string, "%m/%d/%Y", &tm)     ? "%m/%d/%Y"
-                                                     : NULL;
-
-    if (!success) {
+    if (!strptime(date_string, "%Y-%m-%d", &tm) &&
+    	!strptime(date_string, "%d.%m.%Y", &tm) &&
+    	!strptime(date_string, "%m/%d/%Y", &tm)) {
         return -1; // Error
     }
 
@@ -52,7 +41,7 @@ int date_string_to_unix_day(uint64_t* unix_day, char* date_string)
     tm.tm_min = 0;
     tm.tm_sec = 0; // Ensure the time is 00:00:00
     time_t t = timegm(&tm); // interpret the input as UTC, not local time
-    *unix_day = get_unix_day(t);
+    *unix_day = t/SECONDS_PER_DAY;
     return 0; // Success
 }
 
@@ -82,24 +71,24 @@ int main(int argc, char* argv[])
         }
 
         char* end;
-        uint64_t date_flag = strtoull(argv[1], &end, 10);
+        int64_t date_flag = strtoull(argv[1], &end, 10);
 
         if (*end == '\0') { // The argument was a UNIX day number
             char* date = unix_day_to_date(date_flag);
-            printf("%s\n", date);
+            puts(date);
             free(date);
         } else { // The argument was a date string
-            uint64_t unix_day;
+            int64_t unix_day;
             int error = date_string_to_unix_day(&unix_day, argv[1]);
             if (error == -1) {
                 fprintf(stderr, "Invalid date or unknown argument: %s\n", argv[1]);
                 print_usage(argv[0]);
                 return EXIT_FAILURE;
             }
-            printf("%" PRIu64 "\n", unix_day);
+            printf("%" PRIi64 "\n", unix_day);
         }
     } else {
-        printf("%" PRIu64 "\n", get_unix_day(time(NULL)));
+        printf("%" PRIi64 "\n", time(NULL)/SECONDS_PER_DAY);
     }
 
     return EXIT_SUCCESS;


### PR DESCRIPTION
- Give error code on failed `malloc()`
- type for day is singed instead of unsigned (1969-12-30 != 18446744073709551614)
- Remove `get_unix_day()` (single division)
- `printf("%s\n")` -> puts()
- collapse `strptime()` parsing checks into a single if statment.